### PR TITLE
do not throw when codec_type = "data"

### DIFF
--- a/src/main/scala/org/matthicks/media4s/video/info/MediaInfo.scala
+++ b/src/main/scala/org/matthicks/media4s/video/info/MediaInfo.scala
@@ -56,6 +56,7 @@ object MediaInfo {
           if (audioInfo.nonEmpty) throw new RuntimeException("Multiple audio formats detected!")
           audioInfo = Some(audio)
         }
+        case "data" => {}
         case codecType => throw new RuntimeException(s"Unsupported codec_type: $codecType.")
       }
     }


### PR DESCRIPTION
VideoInfo fails when video contains a stream of codec_type = "data"